### PR TITLE
Set Accept Headers for JSON responses

### DIFF
--- a/Html5UploadDemo/Scripts/src/html5Upload.js
+++ b/Html5UploadDemo/Scripts/src/html5Upload.js
@@ -164,6 +164,7 @@ define(function () {
             fileName = file.name;
 
             xhr.open('POST', manager.uploadUrl);
+            xhr.setRequestHeader('Accept', 'application/json, text/javascript', '*/*');
 
             // Triggered when upload starts:
             xhr.upload.onloadstart = function () {


### PR DESCRIPTION
When sending the response Accept headers should be sent so that the serve can detect that this request may want a JSON response and return data accordingly.
The wildcard accepts header at the end tell the server that we will also accept any response including HTML. 

Adding this means that from the server I can send down a JSON response when I use this plugin. 
But send down a HTTP redirect & HTML response otherwise.
